### PR TITLE
Fix cards spaces

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -12,13 +12,14 @@ const Content = styled.div`
     margin-top: auto;
 `;
 
-const TitleWrapper = styled.div`
-    margin-bottom: 16px;
+const Header = styled.div`
+  margin-bottom: 8px;
+`;
 
+const TitleWrapper = styled.div`
     @media (min-width: 769px) {
         display: flex;
         justify-content: space-between;
-        margin-bottom: 0;
     }
 `;
 
@@ -36,33 +37,35 @@ export default function Box(props: IBoxProps) {
 
     return (
         <BoxContainer>
-            {(title || legend) && (
-                <TitleWrapper>
-                    {title && (
-                        <Typography variant="h6" style={{ marginBottom: '8px' }}>
-                            {title}
-                        </Typography>
-                    )}
-                    {legend && <Typography variant="caption">{legend}</Typography>}
-                </TitleWrapper>
-            )}
-            {(subtitle || postsubtitle) && (
-                <div>
-                    {subtitle && (
-                        <Typography
-                            variant="h3"
-                            display="inline"
-                            style={{
-                                marginBottom: children ? '19px' : '0px',
-                                fontFamily: 'Gelion-SemiBold'
-                            }}
-                        >
-                            {subtitle}
-                        </Typography>
-                    )}
-                    {postsubtitle && <Typography variant="subtitle2" style={{ display: 'inline', marginLeft: subtitle ? 4 : 0 }}>{postsubtitle}</Typography>}
-                </div>
-            )}
+            <Header>
+              {(title || legend) && (
+                  <TitleWrapper>
+                      {title && (
+                          <Typography variant="h6" style={{ marginBottom: '8px' }}>
+                              {title}
+                          </Typography>
+                      )}
+                      {legend && <Typography variant="caption">{legend}</Typography>}
+                  </TitleWrapper>
+              )}
+              {(subtitle || postsubtitle) && (
+                  <div>
+                      {subtitle && (
+                          <Typography
+                              variant="h3"
+                              display="inline"
+                              style={{
+                                  marginBottom: children ? '19px' : '0px',
+                                  fontFamily: 'Gelion-SemiBold'
+                              }}
+                          >
+                              {subtitle}
+                          </Typography>
+                      )}
+                      {postsubtitle && <Typography variant="subtitle2" style={{ display: 'inline', marginLeft: subtitle ? 4 : 0 }}>{postsubtitle}</Typography>}
+                  </div>
+              )}
+            </Header>
             <Content>
                 {children}
             </Content>


### PR DESCRIPTION
This PR will fix the spaces in the card headings (mobile view).

Before:
<img width="364" alt="Screenshot 2021-03-09 at 09 47 45" src="https://user-images.githubusercontent.com/7081017/110451905-92cc4680-80bc-11eb-8b81-0140fd20ee21.png">

After:
<img width="360" alt="Screenshot 2021-03-09 at 09 47 34" src="https://user-images.githubusercontent.com/7081017/110451941-9b248180-80bc-11eb-9858-b6d4556306a0.png">
