### PR TITLE
Add tooltip to demographics

### DIFF
--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -42,7 +42,9 @@ export default function Banner() {
                                 {description}
                             </Typography>
                             <div className={bannerClasses.buttonsWrapper}>
-                                <AppDownloadButtons style={{ marginTop: 32 }} />
+                                <div style={{ flexShrink: 0, minWidth: 286 }}>
+                                  <AppDownloadButtons style={{ marginTop: 32 }} />
+                                </div>
                                 <div className={bannerClasses.donateButtonWrapper}>
                                     <Button fluid onClick={handleDonateButtonClick} white >
                                         Donate
@@ -64,6 +66,7 @@ export default function Banner() {
 const bannerStyles = makeStyles((theme) =>
     createStyles({
         buttonsWrapper: {
+            flexShrink: 0,
             [theme.breakpoints.up('md')]: {
                 display: 'flex',
                 alignItems: 'flex-end',

--- a/src/helpers/demographics.ts
+++ b/src/helpers/demographics.ts
@@ -91,10 +91,12 @@ export const getDemographicsBeneficiariesByCountry = (
 };
 
 export const getDemographicsTotalPercentage = (data: any[] | undefined): number => {
-    const { totalGender, undisclosed } = data?.reduce((result, { totalGender, undisclosed }) => ({
-        totalGender: result.totalGender + totalGender,
-        undisclosed: result.undisclosed + undisclosed,
-    }), { totalGender: 0, undisclosed: 0 });
+    const { total, totalFromGender } = data?.reduce((result, { female, male, totalGender }) => ({
+        total: result.total + totalGender,
+        totalFromGender: result.totalFromGender + female + male,
+    }), { total: 0, totalFromGender: 0 });
 
-    return +((undisclosed / totalGender) * 100).toFixed();
+    const percentage = +((totalFromGender / total) * 100).toFixed();
+
+    return percentage;
 }

--- a/src/helpers/demographics.ts
+++ b/src/helpers/demographics.ts
@@ -85,3 +85,12 @@ export const getDemographicsBeneficiariesByCountry = (
 
     return chunks;
 };
+
+export const getDemographicsTotalPercentage = (data: any[] | undefined): number => {
+    const { totalGender, undisclosed } = data?.reduce((result, { totalGender, undisclosed }) => ({
+        totalGender: result.totalGender + totalGender,
+        undisclosed: result.undisclosed + undisclosed,
+    }), { totalGender: 0, undisclosed: 0 });
+
+    return +((undisclosed / totalGender) * 100).toFixed();
+}

--- a/src/helpers/demographics.ts
+++ b/src/helpers/demographics.ts
@@ -1,6 +1,6 @@
 import { IDemographics } from '../types';
 import countriesJSON from '../constants/countries.json';
-import { chunk, sortBy } from 'lodash';
+import { chunk, sortBy } from 'lodash';
 interface IDataItem {
     label: string;
     value: number;
@@ -70,10 +70,14 @@ export const getDemographicsBeneficiariesByCountry = (
     const result = data.map(({ country: countryCode, female, male, totalGender, undisclosed }) => {
         const country = countries[countryCode]?.name;
 
+        const totalMF = male + female;
+        const nMale = (male / totalMF) * totalGender;
+        const nFemale = (female / totalMF) * totalGender;
+
         return {
             country,
-            female,
-            male,
+            female: totalMF === 0 ? 0 : nFemale,
+            male: totalMF === 0 ? 0 : nMale,
             total: totalGender,
             undisclosed,
         };

--- a/src/theme/components/Tooltip/Tooltip.js
+++ b/src/theme/components/Tooltip/Tooltip.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { mq, transitions } from '../../helpers';
+import { ease, fonts } from '../../variables';
+
+const TooltipWrapper = styled.div`
+    align-items: flex-start;
+    display: inline-flex;
+    height: 100%;
+    justify-content: center;
+    margin-left: 8px;
+    position: relative;
+
+    ${mq.tabletLandscape(css`
+        justify-content: flex-start;
+    `)}
+`;
+
+const Tip = styled.div`
+    ${transitions('all', 750, ease.outQuart)};
+
+    background-color: #ffffff;
+    border-radius: 8px;
+    border: 1px solid #E1E4E7;
+    box-shadow: 0px 4px 24px rgba(0, 0, 0, 0.1);
+    box-sizing: border-box;
+    font-family: ${fonts.families.sans};
+    font-size: 16px;
+    line-height: 26px;
+    opacity: 0;
+    padding: 22px;
+    position: absolute;
+    top: 100%;
+    transform: translate(0, 32px);
+    visibility: hidden;
+    width: 192px;
+    z-index: 999;
+
+    ${mq.tabletLandscape(css`
+        top: unset;
+        transform: translate(46px, -10px);
+        width: 324px;
+    `)}
+`;
+
+const TipIcon = styled.div`
+    align-items: flex-start;
+    display: flex;
+    height: 16px;
+    justify-content: flex-start;
+    width: 16px;
+
+    &:hover {
+        & ~ ${Tip} {
+            opacity: 1;
+            transform: translate(0, 10px);
+            visibility: visible;
+
+            ${mq.tabletLandscape(css`
+                transform: translate(26px, -10px);
+            `)}
+        }
+    }
+`;
+
+export const Tooltip = props => {
+    const { children } = props;
+
+    return (
+        <TooltipWrapper>
+            <TipIcon>
+                <svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M8 0a8 8 0 100 16A8 8 0 008 0zm.338 3.165a1.052 1.052 0 110 2.103 1.052 1.052 0 010-2.103zm.943 9.304s-.828.695-1.872.171a1.35 1.35 0 01-.553-.538c-.354-.627-.218-1.3-.218-1.3l.105-.824.27-2.151-.737.016a.623.623 0 01-.242-1.204l1.888-.743a.874.874 0 011.173 1.008l-.025.112-.739 3.242-.184.81c-.027.122-.031.15-.039.214-.02.365.499.091.499.091a.643.643 0 01.674 1.096z" fill="#73839D"/>
+                </svg>
+            </TipIcon>
+            <Tip>
+                {children}
+            </Tip>
+        </TooltipWrapper>
+    )
+}
+
+Tooltip.propTypes = {
+    children: PropTypes.any,
+}

--- a/src/theme/components/index.js
+++ b/src/theme/components/index.js
@@ -7,3 +7,4 @@ export * from './ItemsRow/ItemsRow';
 export * from './Logo/Logo';
 export * from './Spinner/Spinner';
 export * from './Text/Text';
+export * from './Tooltip/Tooltip';


### PR DESCRIPTION
This PR adds a tooltip to demographics, reverts the country bar chart to present the correct values and fixes the app stores buttons shrink bug.

<img width="1207" alt="Screenshot 2021-03-11 at 02 00 05" src="https://user-images.githubusercontent.com/7081017/110724364-8f94a000-820d-11eb-99ca-bb324ba22529.png">

<img width="359" alt="Screenshot 2021-03-11 at 01 59 52" src="https://user-images.githubusercontent.com/7081017/110724379-93282700-820d-11eb-8f56-3e34f2ddf55d.png">
